### PR TITLE
vSwitch name is required

### DIFF
--- a/hetznerrobot/resource_vswitch.go
+++ b/hetznerrobot/resource_vswitch.go
@@ -22,7 +22,7 @@ func resourceVSwitch() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:        schema.TypeString,
-				Optional:    true,
+				Required:    true,
 				Description: "vSwitch name",
 			},
 			"vlan": {


### PR DESCRIPTION
`tofu apply` fails:

```
OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated   with the following symbols:
  + create

OpenTofu will perform the following actions:

  # hetzner-robot_vswitch.test will be created
  + resource "hetzner-robot_vswitch" "test" {
      + cloud_networks = (known after apply)
      + id             = (known after apply)
      + is_cancelled   = (known after apply)
      + subnets        = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  OpenTofu will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

hetzner-robot_vswitch.test: Creating...
╷
│ Error: Unable to create VSwitch :
│        "hetzner webservice response status 400: {\"error\":{\"status\":400,\"code\":\"INVALID_INPUT\",\"message\":\"invalid input\",\"missing\":[\"name\"],\"invalid\":[\"vlan\"]}}"                                          
│
│   with hetzner-robot_vswitch.test,
│   on main.tf line 15, in resource "hetzner-robot_vswitch" "test":                                             
│   15: resource "hetzner-robot_vswitch" "test" {
│