### PR TITLE
vSwitch vlan is required

### DIFF
--- a/hetznerrobot/resource_vswitch.go
+++ b/hetznerrobot/resource_vswitch.go
@@ -27,7 +27,7 @@ func resourceVSwitch() *schema.Resource {
 			},
 			"vlan": {
 				Type:        schema.TypeInt,
-				Optional:    true,
+				Required:    true,
 				Description: "VLAN ID",
 			},
 			// computed / read-only fields


### PR DESCRIPTION
`tofu apply` fails:
```
OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated
with the following symbols:
  + create

OpenTofu will perform the following actions:

  # hetzner-robot_vswitch.test will be created
  + resource "hetzner-robot_vswitch" "test" {
      + cloud_networks = (known after apply)
      + id             = (known after apply)
      + is_cancelled   = (known after apply)
      + name           = "test"
      + subnets        = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  OpenTofu will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

hetzner-robot_vswitch.test: Creating...
╷
│ Error: Unable to create VSwitch :
│        "hetzner webservice response status 400: {\"error\":{\"status\":400,\"code\":\"INVALID_INPUT\",\"message\":\"invalid input\",\"missing\":null,\"invalid\":[\"vlan\"]}}"
│
│   with hetzner-robot_vswitch.test,
│   on main.tf line 15, in resource "hetzner-robot_vswitch" "test":
│   15: resource "hetzner-robot_vswitch" "test" {
│
╵
```