### PR TITLE
Fix format string issues and remove unused import

### DIFF
--- a/hetznerrobot/client_vswitch.go
+++ b/hetznerrobot/client_vswitch.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"time"
 )
 
 type HetznerRobotVSwitchServer struct {

--- a/hetznerrobot/data_boot.go
+++ b/hetznerrobot/data_boot.go
@@ -60,7 +60,7 @@ func dataSourceBootRead(ctx context.Context, d *schema.ResourceData, meta interf
 	serverID := d.Id()
 	boot, err := c.getBoot(ctx, serverID)
 	if err != nil {
-		return diag.Errorf("Unable to find Boot Profile for server ID %d:\n\t %q", serverID, err)
+		return diag.Errorf("Unable to find Boot Profile for server ID %s:\n\t %q", serverID, err)
 	}
 
 	d.Set("active_profile", boot.ActiveProfile)

--- a/hetznerrobot/data_server.go
+++ b/hetznerrobot/data_server.go
@@ -140,7 +140,7 @@ func dataSourceServerRead(ctx context.Context, d *schema.ResourceData, meta inte
 
 	server, err := c.getServer(ctx, serverNumber)
 	if err != nil {
-		return diag.Errorf("Unable to find Server with IP %s:\n\t %q", serverNumber, err)
+		return diag.Errorf("Unable to find Server with IP %d:\n\t %q", serverNumber, err)
 	}
 	d.Set("datacenter", server.DataCenter)
 	d.Set("is_cancelled", server.Cancelled)

--- a/hetznerrobot/data_vswitch.go
+++ b/hetznerrobot/data_vswitch.go
@@ -106,7 +106,7 @@ func dataSourceVSwitchRead(ctx context.Context, d *schema.ResourceData, meta int
 	vSwitchID := d.Id()
 	vSwitch, err := c.getVSwitch(ctx, vSwitchID)
 	if err != nil {
-		return diag.Errorf("Unable to find VSwitch with ID %d:\n\t %q", vSwitchID, err)
+		return diag.Errorf("Unable to find VSwitch with ID %s:\n\t %q", vSwitchID, err)
 	}
 
 	d.Set("name", vSwitch.Name)

--- a/hetznerrobot/resource_vswitch.go
+++ b/hetznerrobot/resource_vswitch.go
@@ -116,7 +116,7 @@ func resourceVSwitchImportState(ctx context.Context, d *schema.ResourceData, met
 	vSwitchID := d.Id()
 	vSwitch, err := c.getVSwitch(ctx, vSwitchID)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to find VSwitch with ID %d:\n\t %q", vSwitchID, err)
+		return nil, fmt.Errorf("Unable to find VSwitch with ID %s:\n\t %q", vSwitchID, err)
 	}
 
 	d.Set("name", vSwitch.Name)


### PR DESCRIPTION
## Summary
- Fix format string type mismatches in multiple files
- Remove unused 'time' import from client_vswitch

These are build fixes found during feature development.

## Changes
- `hetznerrobot/client_vswitch.go`: remove unused 'time' import
- `hetznerrobot/data_boot.go`: %d → %s (serverID is string)
- `hetznerrobot/data_server.go`: %s → %d (serverNumber is int)
- `hetznerrobot/data_vswitch.go`: %d → %s (vSwitchID is string)
- `hetznerrobot/resource_vswitch.go`: %d → %s (vSwitchID is string)

## Test Plan
- [x] go build
- [x] go test ./hetznerrobot/...