### PR TITLE
Add SSH key management and update boot resource

### DIFF
--- a/hetznerrobot/client_boot.go
+++ b/hetznerrobot/client_boot.go
@@ -14,19 +14,18 @@ import (
 
 type BootProfile struct {
 	ActiveProfile   string // linux/rescue/...
-	Architecture    string
 	AuthorizedKeys  []string
 	HostKeys        []string
 	Language        string
 	OperatingSystem string
 	Password        string
-	ServerID        int
+	ServerNumber    int
 	ServerIPv4      string
 	ServerIPv6      string
 }
 
-func (c *HetznerRobotClient) getBoot(ctx context.Context, serverID string) (*BootProfile, error) {
-	bytes, err := c.makeAPICall(ctx, "GET", fmt.Sprintf("%s/boot/%s", c.url, serverID), nil, []int{http.StatusOK, http.StatusAccepted})
+func (c *HetznerRobotClient) getBoot(ctx context.Context, serverNumber int) (*BootProfile, error) {
+	bytes, err := c.makeAPICall(ctx, "GET", fmt.Sprintf("%s/boot/%d", c.url, serverNumber), nil, []int{http.StatusOK, http.StatusAccepted})
 	if err != nil {
 		return nil, err
 	}
@@ -47,20 +46,18 @@ func (c *HetznerRobotClient) getBoot(ctx context.Context, serverID string) (*Boo
 		bootProfile.OperatingSystem = gjson.Get(activeBoot, "os").String()
 	}
 
-	bootProfile.Architecture = gjson.Get(activeBoot, "arch").String()
 	// bootProfile.AuthorizedKeys = gjson.Get(activeBoot, "authorised_keys").Array()
 	// bootProfile.HostKeys = gjson.Get(activeBoot, "host_keys").Array()
 	bootProfile.Password = gjson.Get(activeBoot, "password").String()
-	bootProfile.ServerID = int(gjson.Get(activeBoot, "server_num").Int())
+	bootProfile.ServerNumber = int(gjson.Get(activeBoot, "server_number").Int())
 	bootProfile.ServerIPv4 = gjson.Get(activeBoot, "server_ip").String()
 	bootProfile.ServerIPv6 = gjson.Get(activeBoot, "server_ipv6_net").String()
 
 	return &bootProfile, nil
 }
 
-func (c *HetznerRobotClient) setBootProfile(ctx context.Context, serverID string, activeBootProfile string, arch string, os string, lang string, authorizedKeys []string) (*BootProfile, error) {
+func (c *HetznerRobotClient) setBootProfile(ctx context.Context, serverNumber int, activeBootProfile string, os string, lang string, authorizedKeys []string) (*BootProfile, error) {
 	data := url.Values{}
-	data.Set("arch", arch)
 	for _, key := range authorizedKeys {
 		data.Add("authorized_key", key)
 	}
@@ -72,10 +69,10 @@ func (c *HetznerRobotClient) setBootProfile(ctx context.Context, serverID string
 		data.Set("os", os)
 	}
 
-	bytes, err := c.makeAPICall(ctx, "POST", fmt.Sprintf("%s/boot/%s/%s", c.url, serverID, activeBootProfile), data, []int{http.StatusOK, http.StatusAccepted})
+	bytes, err := c.makeAPICall(ctx, "POST", fmt.Sprintf("%s/boot/%d/%s", c.url, serverNumber, activeBootProfile), data, []int{http.StatusOK, http.StatusAccepted})
 	if err != nil {
 		if strings.Contains(err.Error(), "BOOT_ALREADY_ENABLED") {
-			return c.getBoot(ctx, serverID)
+			return c.getBoot(ctx, serverNumber)
 		}
 		return nil, err
 	}
@@ -96,11 +93,10 @@ func (c *HetznerRobotClient) setBootProfile(ctx context.Context, serverID string
 		bootProfile.OperatingSystem = gjson.Get(activeBoot, "os").String()
 	}
 
-	bootProfile.Architecture = gjson.Get(activeBoot, "arch").String()
 	// bootProfile.AuthorizedKeys = gjson.Get(activeBoot, "authorised_keys").Array()
 	// bootProfile.HostKeys = gjson.Get(activeBoot, "host_keys").Array()
 	bootProfile.Password = gjson.Get(activeBoot, "password").String()
-	bootProfile.ServerID = int(gjson.Get(activeBoot, "server_num").Int())
+	bootProfile.ServerNumber = int(gjson.Get(activeBoot, "server_number").Int())
 	bootProfile.ServerIPv4 = gjson.Get(activeBoot, "server_ip").String()
 	bootProfile.ServerIPv6 = gjson.Get(activeBoot, "server_ipv6_net").String()
 

--- a/hetznerrobot/client_ssh_key.go
+++ b/hetznerrobot/client_ssh_key.go
@@ -1,0 +1,80 @@
+package hetznerrobot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+type SshKeyWrapper struct {
+	Key SshKey `json:"key"`
+}
+
+type SshKey struct {
+	Name        string `json:"name"`
+	Fingerprint string `json:"fingerprint"`
+	Type        string `json:"type"`
+	Size        int    `json:"size"`
+	Data        string `json:"data"`
+	CreatedAt   string `json:"created_at"`
+}
+
+func (c *HetznerRobotClient) getSshKey(ctx context.Context, keyFingerprint string) (*SshKey, error) {
+	bytes, err := c.makeAPICall(ctx, "GET", fmt.Sprintf("%s/key/%s", c.url, keyFingerprint), nil, []int{http.StatusOK, http.StatusCreated, http.StatusAccepted})
+	if err != nil {
+		return nil, err
+	}
+
+	sshKeyWrapper := SshKeyWrapper{}
+	if err = json.Unmarshal(bytes, &sshKeyWrapper); err != nil {
+		return nil, err
+	}
+
+	return &sshKeyWrapper.Key, nil
+}
+
+func (c *HetznerRobotClient) createSshKey(ctx context.Context, name string, data string) (*SshKey, error) {
+	body := url.Values{}
+	body.Set("name", name)
+	body.Set("data", data)
+
+	bytes, err := c.makeAPICall(ctx, "POST", fmt.Sprintf("%s/key", c.url), body, []int{http.StatusOK, http.StatusCreated, http.StatusAccepted})
+	if err != nil {
+		return nil, err
+	}
+
+	sshKeyWrapper := SshKeyWrapper{}
+	if err = json.Unmarshal(bytes, &sshKeyWrapper); err != nil {
+		return nil, err
+	}
+
+	return &sshKeyWrapper.Key, nil
+}
+
+func (c *HetznerRobotClient) updateSshKey(ctx context.Context, keyFingerprint string, newName string) (*SshKey, error) {
+	body := url.Values{}
+	body.Set("name", newName)
+
+	bytes, err := c.makeAPICall(ctx, "PUT", fmt.Sprintf("%s/key/%s", c.url, keyFingerprint), body, []int{http.StatusOK, http.StatusCreated, http.StatusAccepted})
+	if err != nil {
+		return nil, err
+	}
+
+	sshKeyWrapper := SshKeyWrapper{}
+	if err = json.Unmarshal(bytes, &sshKeyWrapper); err != nil {
+		return nil, err
+	}
+
+	return &sshKeyWrapper.Key, nil
+}
+
+func (c *HetznerRobotClient) deleteSshKey(ctx context.Context, keyFingerprint string) error {
+	_, err := c.makeAPICall(ctx, "DELETE", fmt.Sprintf("%s/key/%s", c.url, keyFingerprint), nil, []int{http.StatusOK, http.StatusCreated, http.StatusAccepted})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/hetznerrobot/data_ssh_key.go
+++ b/hetznerrobot/data_ssh_key.go
@@ -1,0 +1,66 @@
+package hetznerrobot
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSshKey() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSshKeyRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Key name",
+			},
+			"data": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Key data in OpenSSH or SSH2 format",
+			},
+			"fingerprint": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Key fingerprint",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Key algorithm type",
+			},
+			"size": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Key size in bits",
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Creation date",
+			},
+		},
+	}
+}
+
+func dataSourceSshKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(HetznerRobotClient)
+
+	keyFingerprint := d.Id()
+
+	key, err := c.getSshKey(ctx, keyFingerprint)
+	if err != nil {
+		return diag.Errorf("Unable to find SSH key %q:\n\t %q", keyFingerprint, err)
+	}
+
+	d.Set("name", key.Name)
+	d.Set("data", key.Data)
+	d.Set("fingerprint", key.Fingerprint)
+	d.Set("type", key.Type)
+	d.Set("size", key.Size)
+	d.Set("created_at", key.CreatedAt)
+
+	return diag.Diagnostics{}
+}

--- a/hetznerrobot/data_ssh_key.go
+++ b/hetznerrobot/data_ssh_key.go
@@ -48,7 +48,7 @@ func dataSshKey() *schema.Resource {
 func dataSourceSshKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(HetznerRobotClient)
 
-	keyFingerprint := d.Id()
+	keyFingerprint := d.Get("fingerprint").(string)
 
 	key, err := c.getSshKey(ctx, keyFingerprint)
 	if err != nil {
@@ -61,6 +61,8 @@ func dataSourceSshKeyRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Set("type", key.Type)
 	d.Set("size", key.Size)
 	d.Set("created_at", key.CreatedAt)
+
+	d.SetId(key.Fingerprint)
 
 	return diag.Diagnostics{}
 }

--- a/hetznerrobot/provider.go
+++ b/hetznerrobot/provider.go
@@ -29,11 +29,13 @@ func Provider() *schema.Provider {
 		ResourcesMap: map[string]*schema.Resource{
 			"hetzner-robot_boot":     resourceBoot(),
 			"hetzner-robot_firewall": resourceFirewall(),
+			"hetzner-robot_ssh_key":  resourceSshKey(),
 			"hetzner-robot_vswitch":  resourceVSwitch(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"hetzner-robot_boot":    dataBoot(),
 			"hetzner-robot_server":  dataServer(),
+			"hetzner-robot_ssh_key": dataSshKey(),
 			"hetzner-robot_vswitch": dataVSwitch(),
 		},
 		ConfigureContextFunc: providerConfigure,

--- a/hetznerrobot/resource_ssh_key.go
+++ b/hetznerrobot/resource_ssh_key.go
@@ -1,0 +1,152 @@
+package hetznerrobot
+
+import (
+	"context"
+	"errors"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"regexp"
+)
+
+func resourceSshKey() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSshKeyCreate,
+		ReadContext:   resourceSshKeyRead,
+		UpdateContext: resourceSshKeyUpdate,
+		DeleteContext: resourceSshKeyDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceSshKeyImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Key name",
+			},
+			"data": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Key data in OpenSSH or SSH2 format",
+				ForceNew:    true,
+			},
+			"fingerprint": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Key fingerprint",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Key algorithm type",
+			},
+			"size": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Key size in bits",
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Creation date",
+			},
+		},
+	}
+}
+
+func resourceSshKeyImportState(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	c := meta.(HetznerRobotClient)
+
+	keyFingerprint := d.Id()
+	match, err := regexp.Match(`^[0-9a-f]{2}(:[0-9a-f]{2}){15}$`, []byte(keyFingerprint))
+	if err != nil {
+		return nil, err
+	}
+	if !match {
+		return nil, errors.New("invalid key fingerprint format")
+	}
+
+	key, err := c.getSshKey(ctx, keyFingerprint)
+	if err != nil {
+		return nil, err
+	}
+
+	d.Set("name", key.Name)
+	d.Set("data", key.Data)
+	d.Set("fingerprint", key.Fingerprint)
+	d.Set("type", key.Type)
+	d.Set("size", key.Size)
+	d.Set("created_at", key.CreatedAt)
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func resourceSshKeyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(HetznerRobotClient)
+
+	name := d.Get("name").(string)
+	data := d.Get("data").(string)
+
+	key, err := c.createSshKey(ctx, name, data)
+	if err != nil {
+		return diag.Errorf("Unable to create SSH key %q:\n\t %q", name, err)
+	}
+
+	d.Set("fingerprint", key.Fingerprint)
+	d.Set("type", key.Type)
+	d.Set("size", key.Size)
+	d.Set("created_at", key.CreatedAt)
+	d.SetId(key.Fingerprint)
+
+	return diag.Diagnostics{}
+}
+
+func resourceSshKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(HetznerRobotClient)
+
+	keyFingerprint := d.Id()
+
+	key, err := c.getSshKey(ctx, keyFingerprint)
+	if err != nil {
+		return diag.Errorf("Unable to find SSH key %q:\n\t %q", keyFingerprint, err)
+	}
+
+	d.Set("name", key.Name)
+	d.Set("data", key.Data)
+	d.Set("fingerprint", key.Fingerprint)
+	d.Set("type", key.Type)
+	d.Set("size", key.Size)
+	d.Set("created_at", key.CreatedAt)
+
+	return diag.Diagnostics{}
+}
+
+func resourceSshKeyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(HetznerRobotClient)
+
+	keyFingerprint := d.Id()
+	name := d.Get("name").(string)
+
+	key, err := c.updateSshKey(ctx, keyFingerprint, name)
+	if err != nil {
+		return diag.Errorf("Unable to update SSH key %q:\n\t %q", keyFingerprint, err)
+	}
+
+	d.Set("name", key.Name)
+
+	return diag.Diagnostics{}
+}
+
+func resourceSshKeyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(HetznerRobotClient)
+
+	keyFingerprint := d.Id()
+
+	err := c.deleteSshKey(ctx, keyFingerprint)
+	if err != nil {
+		return diag.Errorf("Unable to delete SSH key %q:\n\t %q", keyFingerprint, err)
+	}
+
+	return diag.Diagnostics{}
+}


### PR DESCRIPTION
## Summary
- Add SSH key resource and data source
- **Breaking**: boot resource server_id → server_number (int type)
- **Breaking**: remove architecture field (not supported by API)

**Depends on:** #8 (bugfixes) - should be merged first

Source: https://github.com/silenium-dev/terraform-provider-hetzner-robot (v3.6.0)

## Breaking Changes
Users will need to update their Terraform configs:
- Change `server_id` to `server_number` in boot resources
- Remove `architecture` field from boot resources

## Test Plan
- [x] go build
- [x] go test ./hetznerrobot/...
- [ ] SSH key CRUD operations
- [ ] Boot resource with server_number